### PR TITLE
Configuração do CORS

### DIFF
--- a/jornadamilhas/pom.xml
+++ b/jornadamilhas/pom.xml
@@ -50,6 +50,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-vertx-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>

--- a/jornadamilhas/src/main/resources/application.properties
+++ b/jornadamilhas/src/main/resources/application.properties
@@ -8,3 +8,7 @@ quarkus.datasource.jdbc.max-size=15
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.sql-load-script=import.sql
+
+quarkus.http.cors=true
+quarkus.http.cors.origins=*
+quarkus.http.cors.headers=Access-Control-Allow-Origin


### PR DESCRIPTION
Adicionado quarkus-vertx-http para configuração do CORS no application.proprietes.

O quarkus-vertx-http foi adicionado com o comando: quarkus ext add quarkus-vertx-http